### PR TITLE
Add preset management UI with JSON import/export

### DIFF
--- a/app/src/main/java/com/example/ssplite/ui/FilterScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/FilterScreen.kt
@@ -1,17 +1,162 @@
 package com.example.ssplite.ui
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.annotation.RawRes
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
+import com.example.ssplite.R
+import com.example.ssplite.model.Preset
+import com.example.ssplite.model.PresetStore
+
+data class SystemPreset(val name: String, @RawRes val resId: Int)
 
 @Composable
 fun FilterScreen(navController: NavController) {
+    val context = LocalContext.current
+
+    val systemPresets = listOf(
+        SystemPreset("Soziale Stimme", R.raw.social_voice),
+        SystemPreset("Kinderstimme", R.raw.kinderstimme),
+        SystemPreset("Männerstimme", R.raw.maennerstimme)
+    )
+
+    var currentPreset by remember { mutableStateOf<Preset?>(null) }
+    var selectedPreset by remember { mutableStateOf<SystemPreset?>(null) }
+    var presetMenuExpanded by remember { mutableStateOf(false) }
+
+    val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
+        uri?.let {
+            context.contentResolver.openInputStream(it)?.use { stream ->
+                currentPreset = PresetStore.load(stream)
+                selectedPreset = null
+            }
+        }
+    }
+
+    val exportLauncher = rememberLauncherForActivityResult(ActivityResultContracts.CreateDocument("application/json")) { uri ->
+        if (uri != null) {
+            currentPreset?.let { preset ->
+                context.contentResolver.openOutputStream(uri)?.use { stream ->
+                    PresetStore.save(stream, preset)
+                }
+            }
+        }
+    }
+
     Column(Modifier.padding(16.dp)) {
-        Text("Filter presets coming soon")
-        Spacer(Modifier.height(8.dp))
-        Button(onClick = { navController.popBackStack() }) { Text("Zurück") }
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+            Box {
+                Button(onClick = { presetMenuExpanded = true }) {
+                    Text(selectedPreset?.name ?: "System-Preset")
+                }
+                DropdownMenu(expanded = presetMenuExpanded, onDismissRequest = { presetMenuExpanded = false }) {
+                    systemPresets.forEach { preset ->
+                        DropdownMenuItem(
+                            text = { Text(preset.name) },
+                            onClick = {
+                                presetMenuExpanded = false
+                                context.resources.openRawResource(preset.resId).use {
+                                    currentPreset = PresetStore.load(it)
+                                }
+                                selectedPreset = preset
+                            }
+                        )
+                    }
+                }
+            }
+            Button(onClick = { navController.popBackStack() }) { Text("Zurück") }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        Row {
+            Button(onClick = { importLauncher.launch(arrayOf("application/json")) }) { Text("Import") }
+            Spacer(Modifier.width(8.dp))
+            Button(onClick = {
+                currentPreset?.let { exportLauncher.launch("${it.name}.json") }
+            }) { Text("Export") }
+        }
+
+        Spacer(Modifier.height(16.dp))
+
+        currentPreset?.let { preset ->
+            OutlinedTextField(
+                value = preset.name,
+                onValueChange = { name -> currentPreset = preset.copy(name = name) },
+                label = { Text("Name") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = preset.eq.low_shelf.gain_db.toString(),
+                onValueChange = { text ->
+                    text.toFloatOrNull()?.let { gain ->
+                        currentPreset = preset.copy(
+                            eq = preset.eq.copy(
+                                low_shelf = preset.eq.low_shelf.copy(gain_db = gain)
+                            )
+                        )
+                    }
+                },
+                label = { Text("Low Shelf Gain (dB)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = preset.eq.high_shelf.gain_db.toString(),
+                onValueChange = { text ->
+                    text.toFloatOrNull()?.let { gain ->
+                        currentPreset = preset.copy(
+                            eq = preset.eq.copy(
+                                high_shelf = preset.eq.high_shelf.copy(gain_db = gain)
+                            )
+                        )
+                    }
+                },
+                label = { Text("High Shelf Gain (dB)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = preset.modulation.rate_hz.toString(),
+                onValueChange = { text ->
+                    text.toFloatOrNull()?.let { rate ->
+                        currentPreset = preset.copy(
+                            modulation = preset.modulation.copy(rate_hz = rate)
+                        )
+                    }
+                },
+                label = { Text("Modulation Rate (Hz)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            OutlinedTextField(
+                value = preset.dynamics.pregain_db.toString(),
+                onValueChange = { text ->
+                    text.toFloatOrNull()?.let { pg ->
+                        currentPreset = preset.copy(
+                            dynamics = preset.dynamics.copy(pregain_db = pg)
+                        )
+                    }
+                },
+                label = { Text("Pregain (dB)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }
+

--- a/app/src/main/res/raw/kinderstimme.json
+++ b/app/src/main/res/raw/kinderstimme.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Kinderstimme-Fokus",
+  "eq": {
+    "low_shelf": { "fc_hz": 180, "gain_db": -10 },
+    "peaks": [
+      { "fc_hz": 1500, "gain_db": 3, "q": 1.0 },
+      { "fc_hz": 2800, "gain_db": 5, "q": 0.9 }
+    ],
+    "high_shelf": { "fc_hz": 6000, "gain_db": -6 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": false,
+    "rate_hz": 0.05,
+    "depth_db": 0.8,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/app/src/main/res/raw/maennerstimme.json
+++ b/app/src/main/res/raw/maennerstimme.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Männerstimme-Fokus",
+  "eq": {
+    "low_shelf": { "fc_hz": 140, "gain_db": -8 },
+    "peaks": [
+      { "fc_hz": 800, "gain_db": 4, "q": 1.0 },
+      { "fc_hz": 1600, "gain_db": 3, "q": 1.0 }
+    ],
+    "high_shelf": { "fc_hz": 4500, "gain_db": -6 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": true,
+    "rate_hz": 0.04,
+    "depth_db": 0.0,
+    "mode": "fc",
+    "fc_drift_oct": 0.25,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/app/src/main/res/raw/social_voice.json
+++ b/app/src/main/res/raw/social_voice.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Soziale Stimme",
+  "eq": {
+    "low_shelf": { "fc_hz": 150, "gain_db": -10 },
+    "peaks": [
+      { "fc_hz": 1000, "gain_db": 4, "q": 1.0 },
+      { "fc_hz": 2000, "gain_db": 4, "q": 1.0 }
+    ],
+    "high_shelf": { "fc_hz": 5000, "gain_db": -8 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": false,
+    "rate_hz": 0.05,
+    "depth_db": 0.8,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}


### PR DESCRIPTION
## Summary
- Add system presets and editing UI to Filter screen
- Support importing and exporting presets via `PresetStore`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47bd34f2c832c989a9e4e3b798d07