### PR TITLE
Parse presets and add LFO/bypass to audio processor

### DIFF
--- a/app/src/main/java/com/example/ssplite/audio/FfpAudioProcessor.kt
+++ b/app/src/main/java/com/example/ssplite/audio/FfpAudioProcessor.kt
@@ -3,6 +3,7 @@ package com.example.ssplite.audio
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.audio.AudioProcessor.AudioFormat
 import androidx.media3.exoplayer.audio.BaseAudioProcessor
+import com.example.ssplite.model.Preset
 import java.nio.ByteBuffer
 
 /**
@@ -12,40 +13,76 @@ import java.nio.ByteBuffer
 class FfpAudioProcessor : BaseAudioProcessor() {
 
     private val lowShelf = Biquad()
-    private val mid1 = Biquad()
-    private val mid2 = Biquad()
     private val highShelf = Biquad()
+    private val peaks = mutableListOf<Biquad>()
     private val dynamics = Dynamics()
+    private val lfo = Lfo()
+
+    private var sampleRate = 0
+    private var preset: Preset? = null
+    private var bypass = false
+
+    fun setPreset(p: Preset) {
+        preset = p
+        if (sampleRate != 0) applyPreset(p)
+    }
+
+    fun setBypass(enabled: Boolean) {
+        bypass = enabled
+    }
+
+    fun setLfoEnabled(enabled: Boolean) { lfo.enabled = enabled }
+    fun setLfoRateHz(rate: Float) { lfo.rateHz = rate }
+    fun setLfoDepthDb(depth: Float) { lfo.depthDb = depth }
 
     override fun onConfigure(inputAudioFormat: AudioFormat): AudioFormat {
-        val rate = inputAudioFormat.sampleRate
-        lowShelf.setLowShelf(rate.toDouble(), 150.0, -10.0)
-        mid1.setPeaking(rate.toDouble(), 1000.0, 1.0, 4.0)
-        mid2.setPeaking(rate.toDouble(), 2000.0, 1.0, 4.0)
-        highShelf.setHighShelf(rate.toDouble(), 5000.0, -8.0)
+        sampleRate = inputAudioFormat.sampleRate
+        lfo.setSampleRate(sampleRate)
+        preset?.let { applyPreset(it) }
         return inputAudioFormat
+    }
+
+    private fun applyPreset(p: Preset) {
+        val rate = sampleRate.toDouble()
+        lowShelf.setLowShelf(rate, p.eq.low_shelf.fc_hz.toDouble(), p.eq.low_shelf.gain_db.toDouble())
+        highShelf.setHighShelf(rate, p.eq.high_shelf.fc_hz.toDouble(), p.eq.high_shelf.gain_db.toDouble())
+        peaks.clear()
+        p.eq.peaks.forEach { peak ->
+            val b = Biquad()
+            b.setPeaking(rate, peak.fc_hz.toDouble(), peak.q.toDouble(), peak.gain_db.toDouble())
+            peaks.add(b)
+        }
+        dynamics.preGainDb = p.dynamics.pregain_db
+        dynamics.ceilingDbfs = p.dynamics.limiter.ceiling_dbfs
+        lfo.enabled = p.modulation.enabled
+        lfo.rateHz = p.modulation.rate_hz
+        lfo.depthDb = p.modulation.depth_db
     }
 
     override fun queueInput(inputBuffer: ByteBuffer) {
         val out = replaceOutputBuffer(inputBuffer.remaining())
         while (inputBuffer.hasRemaining()) {
             val s = inputBuffer.float
-            var y = lowShelf.process(s)
-            y = mid1.process(y)
-            y = mid2.process(y)
-            y = highShelf.process(y)
-            y = dynamics.process(y)
-            out.putFloat(y)
+            if (bypass) {
+                out.putFloat(s)
+            } else {
+                var y = lowShelf.process(s)
+                peaks.forEach { y = it.process(y) }
+                y = highShelf.process(y)
+                y = dynamics.process(y)
+                y *= lfo.next()
+                out.putFloat(y)
+            }
         }
         out.flip()
     }
 
     override fun onFlush() {
         lowShelf.reset()
-        mid1.reset()
-        mid2.reset()
+        peaks.forEach { it.reset() }
         highShelf.reset()
         dynamics.reset()
+        lfo.reset()
     }
 
     override fun isEnded(): Boolean = false

--- a/app/src/main/java/com/example/ssplite/audio/Lfo.kt
+++ b/app/src/main/java/com/example/ssplite/audio/Lfo.kt
@@ -1,0 +1,32 @@
+package com.example.ssplite.audio
+
+import kotlin.math.PI
+import kotlin.math.sin
+import kotlin.math.pow
+
+/** Simple sine LFO returning a linear gain factor. */
+class Lfo(
+    var enabled: Boolean = false,
+    var rateHz: Float = 0.5f,
+    var depthDb: Float = 0f
+) {
+    private var phase = 0.0
+    private var sampleRate = 44100
+
+    fun setSampleRate(rate: Int) {
+        sampleRate = rate
+    }
+
+    fun reset() {
+        phase = 0.0
+    }
+
+    fun next(): Float {
+        if (!enabled) return 1f
+        val value = sin(2 * PI * phase).toFloat()
+        phase += rateHz / sampleRate
+        if (phase >= 1.0) phase -= 1.0
+        val db = value * depthDb
+        return 10f.pow(db / 20f)
+    }
+}


### PR DESCRIPTION
## Summary
- Allow `FfpAudioProcessor` to load `Preset` objects and update EQ and dynamics at runtime
- Add optional sine LFO modulation and bypass flag with public setters
- Introduce standalone `Lfo` helper class

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a47ebc5008832cb4959f5c4cde6132