### PR TITLE
Add DSP calculation tests and player instrumentation tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -60,5 +60,6 @@ dependencies {
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
     androidTestImplementation("androidx.compose.ui:ui-test-junit4:1.5.5")
+    androidTestImplementation("androidx.media3:media3-test-utils:1.3.1")
     debugImplementation("androidx.compose.ui:ui-test-manifest:1.5.5")
 }

--- a/app/src/androidTest/java/com/example/ssplite/ui/PlaylistNavigationTest.kt
+++ b/app/src/androidTest/java/com/example/ssplite/ui/PlaylistNavigationTest.kt
@@ -1,0 +1,22 @@
+package com.example.ssplite.ui
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.assertIsDisplayed
+import com.example.ssplite.MainActivity
+import org.junit.Rule
+import org.junit.Test
+
+class PlaylistNavigationTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<MainActivity>()
+
+    @Test
+    fun navigateToFilterAndBack() {
+        composeTestRule.onNodeWithText("Filter").performClick()
+        composeTestRule.onNodeWithText("Import").assertIsDisplayed()
+        composeTestRule.onNodeWithText("Zurück").performClick()
+        composeTestRule.onNodeWithText("Filter").assertIsDisplayed()
+    }
+}

--- a/app/src/androidTest/java/com/example/ssplite/ui/SessionStopTest.kt
+++ b/app/src/androidTest/java/com/example/ssplite/ui/SessionStopTest.kt
@@ -1,0 +1,41 @@
+package com.example.ssplite.ui
+
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.navigation.compose.rememberNavController
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import androidx.media3.test.utils.FakeExoPlayer
+import androidx.media3.test.utils.FakeMediaSource
+import androidx.media3.test.utils.FakeTimeline
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class SessionStopTest {
+    @get:Rule
+    val composeTestRule = createAndroidComposeRule<androidx.activity.ComponentActivity>()
+
+    @Test
+    fun sessionCountdownReachesZero() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val player = FakeExoPlayer.Builder(context).build()
+        composeTestRule.mainClock.autoAdvance = false
+        composeTestRule.setContent {
+            val nav = rememberNavController()
+            PlayerScreen(navController = nav, testPlayer = player)
+        }
+        composeTestRule.onNodeWithText("Session (Minuten)").performTextInput("1")
+        composeTestRule.runOnUiThread {
+            player.setMediaSource(FakeMediaSource(FakeTimeline(1)))
+            player.prepare()
+        }
+        composeTestRule.onNodeWithText("Play").performClick()
+        composeTestRule.mainClock.advanceTimeBy(61_000)
+        composeTestRule.onNodeWithText("Restzeit: 00:00").assertIsDisplayed()
+    }
+}

--- a/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
@@ -61,7 +61,7 @@ private fun buildPlaylist(root: DocumentFile?, context: Context): List<Uri> {
 }
 
 @Composable
-fun PlayerScreen(navController: NavController) {
+fun PlayerScreen(navController: NavController, testPlayer: ExoPlayer? = null) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     var treeUri by remember { mutableStateOf<Uri?>(null) }
@@ -72,7 +72,7 @@ fun PlayerScreen(navController: NavController) {
     var targetStopIndex by remember { mutableStateOf<Int?>(null) }
     var countdownJob by remember { mutableStateOf<Job?>(null) }
 
-    val player = remember {
+    val player = testPlayer ?: remember {
         ExoPlayer.Builder(context)
             .setAudioProcessors(listOf(FfpAudioProcessor()))
             .build()

--- a/app/src/test/java/com/example/ssplite/audio/BiquadTest.kt
+++ b/app/src/test/java/com/example/ssplite/audio/BiquadTest.kt
@@ -1,0 +1,17 @@
+package com.example.ssplite.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class BiquadTest {
+    @Test
+    fun peakingWithZeroGainActsAsBypass() {
+        val biquad = Biquad()
+        biquad.setPeaking(fs = 48_000.0, f0 = 1_000.0, q = 1.0, gainDb = 0.0)
+        val input = floatArrayOf(0.5f, -0.25f, 0.125f)
+        input.forEach { sample ->
+            val out = biquad.process(sample)
+            assertEquals(sample, out, 1e-3f)
+        }
+    }
+}

--- a/app/src/test/java/com/example/ssplite/audio/DynamicsTest.kt
+++ b/app/src/test/java/com/example/ssplite/audio/DynamicsTest.kt
@@ -1,0 +1,16 @@
+package com.example.ssplite.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.math.pow
+
+class DynamicsTest {
+    @Test
+    fun preGainAndLimiterApplied() {
+        val dyn = Dynamics(preGainDb = 6f, ceilingDbfs = -1f)
+        val ceiling = 10f.pow(-1f / 20f)
+        val input = 1f
+        val out = dyn.process(input)
+        assertEquals(ceiling, out, 1e-6f)
+    }
+}

--- a/app/src/test/java/com/example/ssplite/audio/LfoTest.kt
+++ b/app/src/test/java/com/example/ssplite/audio/LfoTest.kt
@@ -1,0 +1,24 @@
+package com.example.ssplite.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.math.pow
+
+class LfoTest {
+    @Test
+    fun producesSineGainWhenEnabled() {
+        val lfo = Lfo(enabled = true, rateHz = 1f, depthDb = 6f)
+        lfo.setSampleRate(4)
+        val expected = listOf(1f, 10f.pow(6f / 20f), 1f, 10f.pow(-6f / 20f))
+        expected.forEach { exp ->
+            val actual = lfo.next()
+            assertEquals(exp, actual, 1e-4f)
+        }
+    }
+
+    @Test
+    fun returnsUnityWhenDisabled() {
+        val lfo = Lfo(enabled = false)
+        repeat(3) { assertEquals(1f, lfo.next(), 0f) }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for Biquad, Dynamics, and LFO DSP components
- enable player injection for testing and add playlist navigation & session stop instrumentation tests
- add Media3 test utils dependency for Android tests

## Testing
- `gradle test` *(fails: SDK location not found)*
- `gradle connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a48f4b3a30832ca4b6590174223fd3