### PR TITLE
feat: expand preset management and processing controls

### DIFF
--- a/app/src/main/java/com/example/ssplite/audio/AudioEngine.kt
+++ b/app/src/main/java/com/example/ssplite/audio/AudioEngine.kt
@@ -1,0 +1,13 @@
+package com.example.ssplite.audio
+
+import androidx.media3.exoplayer.ExoPlayer
+
+/**
+ * Holds references to the shared audio processor and player so UI screens can
+ * apply changes to the currently running pipeline.
+ */
+object AudioEngine {
+    var processor: FfpAudioProcessor? = null
+    var player: ExoPlayer? = null
+}
+

--- a/app/src/main/java/com/example/ssplite/model/PresetStore.kt
+++ b/app/src/main/java/com/example/ssplite/model/PresetStore.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
+import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -17,5 +18,37 @@ object PresetStore {
 
     fun load(stream: InputStream): Preset {
         return json.decodeFromString(stream.reader().readText())
+    }
+
+    private fun dir(context: Context): File {
+        val d = File(context.filesDir, "presets")
+        if (!d.exists()) d.mkdirs()
+        return d
+    }
+
+    fun list(context: Context): List<String> {
+        return dir(context).listFiles()?.filter { it.extension == "json" }?.map { it.nameWithoutExtension }
+            ?: emptyList()
+    }
+
+    fun save(context: Context, preset: Preset) {
+        val file = File(dir(context), "${preset.name}.json")
+        file.writeText(json.encodeToString(preset))
+    }
+
+    fun load(context: Context, name: String): Preset {
+        val file = File(dir(context), "$name.json")
+        return json.decodeFromString(file.readText())
+    }
+
+    fun import(context: Context, stream: InputStream): Preset {
+        val preset = load(stream)
+        save(context, preset)
+        return preset
+    }
+
+    fun export(context: Context, name: String, stream: OutputStream) {
+        val preset = load(context, name)
+        save(stream, preset)
     }
 }

--- a/app/src/main/java/com/example/ssplite/ui/FilterScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/FilterScreen.kt
@@ -7,18 +7,21 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.example.ssplite.R
 import com.example.ssplite.model.Preset
 import com.example.ssplite.model.PresetStore
+import com.example.ssplite.audio.AudioEngine
 
 data class SystemPreset(val name: String, @RawRes val resId: Int)
 
 @Composable
 fun FilterScreen(navController: NavController) {
     val context = LocalContext.current
+    val processor = AudioEngine.processor
 
     val systemPresets = listOf(
         SystemPreset("Soziale Stimme", R.raw.social_voice),
@@ -26,15 +29,19 @@ fun FilterScreen(navController: NavController) {
         SystemPreset("Männerstimme", R.raw.maennerstimme)
     )
 
+    var userPresets by remember { mutableStateOf(PresetStore.list(context)) }
     var currentPreset by remember { mutableStateOf<Preset?>(null) }
-    var selectedPreset by remember { mutableStateOf<SystemPreset?>(null) }
+    var selectedPreset by remember { mutableStateOf<String?>(null) }
     var presetMenuExpanded by remember { mutableStateOf(false) }
+    var bypass by remember { mutableStateOf(false) }
 
     val importLauncher = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         uri?.let {
             context.contentResolver.openInputStream(it)?.use { stream ->
-                currentPreset = PresetStore.load(stream)
-                selectedPreset = null
+                currentPreset = PresetStore.import(context, stream)
+                selectedPreset = currentPreset?.name
+                userPresets = PresetStore.list(context)
+                processor?.setPreset(currentPreset!!)
             }
         }
     }
@@ -53,7 +60,7 @@ fun FilterScreen(navController: NavController) {
         Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
             Box {
                 Button(onClick = { presetMenuExpanded = true }) {
-                    Text(selectedPreset?.name ?: "System-Preset")
+                    Text(selectedPreset ?: "Preset wählen")
                 }
                 DropdownMenu(expanded = presetMenuExpanded, onDismissRequest = { presetMenuExpanded = false }) {
                     systemPresets.forEach { preset ->
@@ -64,13 +71,34 @@ fun FilterScreen(navController: NavController) {
                                 context.resources.openRawResource(preset.resId).use {
                                     currentPreset = PresetStore.load(it)
                                 }
-                                selectedPreset = preset
+                                selectedPreset = preset.name
+                                processor?.setPreset(currentPreset!!)
+                            }
+                        )
+                    }
+                    userPresets.forEach { name ->
+                        DropdownMenuItem(
+                            text = { Text(name) },
+                            onClick = {
+                                presetMenuExpanded = false
+                                currentPreset = PresetStore.load(context, name)
+                                selectedPreset = name
+                                processor?.setPreset(currentPreset!!)
                             }
                         )
                     }
                 }
             }
-            Button(onClick = { navController.popBackStack() }) { Text("Zurück") }
+            Row {
+                Button(onClick = {
+                    currentPreset?.let {
+                        PresetStore.save(context, it)
+                        userPresets = PresetStore.list(context)
+                    }
+                }) { Text("Save") }
+                Spacer(Modifier.width(8.dp))
+                Button(onClick = { navController.popBackStack() }) { Text("Zurück") }
+            }
         }
 
         Spacer(Modifier.height(16.dp))
@@ -85,6 +113,17 @@ fun FilterScreen(navController: NavController) {
 
         Spacer(Modifier.height(16.dp))
 
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            Text("Bypass")
+            Spacer(Modifier.width(8.dp))
+            Switch(checked = bypass, onCheckedChange = {
+                bypass = it
+                processor?.setBypass(it)
+            })
+        }
+
+        Spacer(Modifier.height(16.dp))
+
         currentPreset?.let { preset ->
             OutlinedTextField(
                 value = preset.name,
@@ -95,66 +134,127 @@ fun FilterScreen(navController: NavController) {
 
             Spacer(Modifier.height(8.dp))
 
-            OutlinedTextField(
-                value = preset.eq.low_shelf.gain_db.toString(),
-                onValueChange = { text ->
-                    text.toFloatOrNull()?.let { gain ->
-                        currentPreset = preset.copy(
-                            eq = preset.eq.copy(
-                                low_shelf = preset.eq.low_shelf.copy(gain_db = gain)
-                            )
+            Text("Low Shelf Gain: ${String.format("%.1f", preset.eq.low_shelf.gain_db)} dB")
+            Slider(
+                value = preset.eq.low_shelf.gain_db,
+                onValueChange = { gain ->
+                    val updated = preset.copy(
+                        eq = preset.eq.copy(
+                            low_shelf = preset.eq.low_shelf.copy(gain_db = gain)
                         )
-                    }
+                    )
+                    currentPreset = updated
+                    processor?.setPreset(updated)
                 },
-                label = { Text("Low Shelf Gain (dB)") },
-                modifier = Modifier.fillMaxWidth()
+                valueRange = -12f..12f
             )
 
             Spacer(Modifier.height(8.dp))
 
-            OutlinedTextField(
-                value = preset.eq.high_shelf.gain_db.toString(),
-                onValueChange = { text ->
-                    text.toFloatOrNull()?.let { gain ->
-                        currentPreset = preset.copy(
-                            eq = preset.eq.copy(
-                                high_shelf = preset.eq.high_shelf.copy(gain_db = gain)
-                            )
+            Text("High Shelf Gain: ${String.format("%.1f", preset.eq.high_shelf.gain_db)} dB")
+            Slider(
+                value = preset.eq.high_shelf.gain_db,
+                onValueChange = { gain ->
+                    val updated = preset.copy(
+                        eq = preset.eq.copy(
+                            high_shelf = preset.eq.high_shelf.copy(gain_db = gain)
                         )
-                    }
+                    )
+                    currentPreset = updated
+                    processor?.setPreset(updated)
                 },
-                label = { Text("High Shelf Gain (dB)") },
-                modifier = Modifier.fillMaxWidth()
+                valueRange = -12f..12f
             )
 
             Spacer(Modifier.height(8.dp))
 
-            OutlinedTextField(
-                value = preset.modulation.rate_hz.toString(),
-                onValueChange = { text ->
-                    text.toFloatOrNull()?.let { rate ->
-                        currentPreset = preset.copy(
-                            modulation = preset.modulation.copy(rate_hz = rate)
-                        )
-                    }
+            preset.eq.peaks.forEachIndexed { index, peak ->
+                Text("Peak ${index + 1} Gain: ${String.format("%.1f", peak.gain_db)} dB")
+                Slider(
+                    value = peak.gain_db,
+                    onValueChange = { gain ->
+                        val peaks = preset.eq.peaks.toMutableList()
+                        peaks[index] = peaks[index].copy(gain_db = gain)
+                        val updated = preset.copy(eq = preset.eq.copy(peaks = peaks))
+                        currentPreset = updated
+                        processor?.setPreset(updated)
+                    },
+                    valueRange = -12f..12f
+                )
+                Spacer(Modifier.height(4.dp))
+                Text("Peak ${index + 1} Q: ${String.format("%.2f", peak.q)}")
+                Slider(
+                    value = peak.q,
+                    onValueChange = { q ->
+                        val peaks = preset.eq.peaks.toMutableList()
+                        peaks[index] = peaks[index].copy(q = q)
+                        val updated = preset.copy(eq = preset.eq.copy(peaks = peaks))
+                        currentPreset = updated
+                        processor?.setPreset(updated)
+                    },
+                    valueRange = 0.1f..10f
+                )
+                Spacer(Modifier.height(8.dp))
+            }
+
+            Text("Modulation Rate: ${String.format("%.1f", preset.modulation.rate_hz)} Hz")
+            Slider(
+                value = preset.modulation.rate_hz,
+                onValueChange = { rate ->
+                    val updated = preset.copy(
+                        modulation = preset.modulation.copy(rate_hz = rate)
+                    )
+                    currentPreset = updated
+                    processor?.setPreset(updated)
                 },
-                label = { Text("Modulation Rate (Hz)") },
-                modifier = Modifier.fillMaxWidth()
+                valueRange = 0f..10f
             )
 
             Spacer(Modifier.height(8.dp))
 
-            OutlinedTextField(
-                value = preset.dynamics.pregain_db.toString(),
-                onValueChange = { text ->
-                    text.toFloatOrNull()?.let { pg ->
-                        currentPreset = preset.copy(
-                            dynamics = preset.dynamics.copy(pregain_db = pg)
-                        )
-                    }
+            Text("Modulation Depth: ${String.format("%.1f", preset.modulation.depth_db)} dB")
+            Slider(
+                value = preset.modulation.depth_db,
+                onValueChange = { depth ->
+                    val updated = preset.copy(
+                        modulation = preset.modulation.copy(depth_db = depth)
+                    )
+                    currentPreset = updated
+                    processor?.setPreset(updated)
                 },
-                label = { Text("Pregain (dB)") },
-                modifier = Modifier.fillMaxWidth()
+                valueRange = 0f..6f
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Text("Pregain: ${String.format("%.1f", preset.dynamics.pregain_db)} dB")
+            Slider(
+                value = preset.dynamics.pregain_db,
+                onValueChange = { pg ->
+                    val updated = preset.copy(
+                        dynamics = preset.dynamics.copy(pregain_db = pg)
+                    )
+                    currentPreset = updated
+                    processor?.setPreset(updated)
+                },
+                valueRange = 0f..24f
+            )
+
+            Spacer(Modifier.height(8.dp))
+
+            Text("Limiter Ceiling: ${String.format("%.1f", preset.dynamics.limiter.ceiling_dbfs)} dBFS")
+            Slider(
+                value = preset.dynamics.limiter.ceiling_dbfs,
+                onValueChange = { ceiling ->
+                    val updated = preset.copy(
+                        dynamics = preset.dynamics.copy(
+                            limiter = preset.dynamics.limiter.copy(ceiling_dbfs = ceiling)
+                        )
+                    )
+                    currentPreset = updated
+                    processor?.setPreset(updated)
+                },
+                valueRange = -40f..0f
             )
         }
     }

--- a/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.unit.dp
 import androidx.documentfile.provider.DocumentFile
 import androidx.media3.common.MediaItem
 import androidx.media3.exoplayer.ExoPlayer
+import com.example.ssplite.audio.AudioEngine
 import com.example.ssplite.audio.FfpAudioProcessor
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -96,10 +97,15 @@ fun PlayerScreen(navController: NavController, testPlayer: ExoPlayer? = null) {
     var targetStopIndex by remember { mutableStateOf<Int?>(null) }
     var countdownJob by remember { mutableStateOf<Job?>(null) }
 
+    val processor = remember {
+        AudioEngine.processor ?: FfpAudioProcessor().also { AudioEngine.processor = it }
+    }
+
     val player = testPlayer ?: remember {
-        ExoPlayer.Builder(context)
-            .setAudioProcessors(listOf(FfpAudioProcessor()))
+        AudioEngine.player ?: ExoPlayer.Builder(context)
+            .setAudioProcessors(listOf(processor))
             .build()
+            .also { AudioEngine.player = it }
     }
 
     val openTree = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->


### PR DESCRIPTION
## Summary
- add PresetStore utilities for listing, saving, loading, importing and exporting presets
- introduce AudioEngine singleton and hook PlayerScreen to shared processor
- overhaul FilterScreen with preset list, bypass toggle and sliders for EQ, modulation and dynamics

## Testing
- `gradle test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68a497f42400832cbc97675da1f74894