### PR TITLE
feat: add UI control for LFO modulation

### DIFF
--- a/app/src/main/java/com/example/ssplite/ui/FilterScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/FilterScreen.kt
@@ -197,6 +197,23 @@ fun FilterScreen(navController: NavController) {
                 Spacer(Modifier.height(8.dp))
             }
 
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text("Modulation")
+                Spacer(Modifier.width(8.dp))
+                Switch(
+                    checked = preset.modulation.enabled,
+                    onCheckedChange = { enabled ->
+                        val updated = preset.copy(
+                            modulation = preset.modulation.copy(enabled = enabled)
+                        )
+                        currentPreset = updated
+                        processor?.setLfoEnabled(enabled)
+                    }
+                )
+            }
+
+            Spacer(Modifier.height(8.dp))
+
             Text("Modulation Rate: ${String.format("%.1f", preset.modulation.rate_hz)} Hz")
             Slider(
                 value = preset.modulation.rate_hz,
@@ -205,7 +222,7 @@ fun FilterScreen(navController: NavController) {
                         modulation = preset.modulation.copy(rate_hz = rate)
                     )
                     currentPreset = updated
-                    processor?.setPreset(updated)
+                    processor?.setLfoRateHz(rate)
                 },
                 valueRange = 0f..10f
             )
@@ -220,7 +237,7 @@ fun FilterScreen(navController: NavController) {
                         modulation = preset.modulation.copy(depth_db = depth)
                     )
                     currentPreset = updated
-                    processor?.setPreset(updated)
+                    processor?.setLfoDepthDb(depth)
                 },
                 valueRange = 0f..6f
             )


### PR DESCRIPTION
## Summary
- allow LFO modulation to be toggled and adjusted without reloading the full preset
- keep preset state in sync while updating the running audio processor via dedicated setters

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a7ef7578832c932750ca9291e7d1