### PR TITLE
Add look-ahead limiter and optional compressor

### DIFF
--- a/app/src/main/java/com/example/ssplite/audio/Dynamics.kt
+++ b/app/src/main/java/com/example/ssplite/audio/Dynamics.kt
@@ -1,25 +1,149 @@
 package com.example.ssplite.audio
 
+import kotlin.math.abs
+import kotlin.math.exp
 import kotlin.math.pow
-import kotlin.math.sign
 
-/** Simple pre-gain and hard limiter. */
+/**
+ * Pre-gain, optional compression and look-ahead limiting.
+ *
+ * The limiter uses a simple buffer based look-ahead design.  A peak is searched
+ * within the current look-ahead window and gain is adjusted to keep the signal
+ * below the configured ceiling.  Gain recovers according to the configured
+ * release time.  A mild feed forward compressor may be enabled which applies a
+ * single pole envelope detector.
+ */
 class Dynamics(
     var preGainDb: Float = -3f,
-    var ceilingDbfs: Float = -1f
+    var ceilingDbfs: Float = -1f,
+    var lookaheadMs: Float = 0f,
+    var releaseMs: Float = 100f
 ) {
+
+    // Sample rate dependent state
+    private var sampleRate: Int = 48_000
+    private var lookaheadSamples = 1
+    private var buffer = FloatArray(lookaheadSamples)
+    private var index = 0
+    private var limiterGain = 1f
+    private var limiterReleaseCoef = 0f
+
+    // Compressor configuration
+    private var compEnabled = false
+    private var compRatio = 1.3f
+    private var compThresholdDbfs = -24f
+    private var compAttackMs = 15f
+    private var compReleaseMs = 120f
+
+    // Compressor state
+    private var compEnv = 0f
+    private var compGain = 1f
+    private var compThreshold = 0f
+    private var compAttackCoef = 0f
+    private var compReleaseCoef = 0f
+
+    init {
+        updateLimiterCoeffs()
+        updateCompressorCoeffs()
+    }
+
+    fun setSampleRate(sr: Int) {
+        sampleRate = sr
+        updateLimiterCoeffs()
+        updateCompressorCoeffs()
+    }
+
+    fun setLookaheadMs(ms: Float) {
+        lookaheadMs = ms
+        updateLimiterCoeffs()
+    }
+
+    fun setReleaseMs(ms: Float) {
+        releaseMs = ms
+        updateLimiterCoeffs()
+    }
+
+    fun setCompressor(
+        enabled: Boolean,
+        ratio: Float,
+        thresholdDbfs: Float,
+        attackMs: Float,
+        releaseMs: Float
+    ) {
+        compEnabled = enabled
+        compRatio = ratio
+        compThresholdDbfs = thresholdDbfs
+        compAttackMs = attackMs
+        compReleaseMs = releaseMs
+        updateCompressorCoeffs()
+    }
+
     private fun preGain(): Float = 10f.pow(preGainDb / 20f)
     private fun ceiling(): Float = 10f.pow(ceilingDbfs / 20f)
 
-    fun process(sample: Float): Float {
-        val x = sample * preGain()
-        val c = ceiling()
-        return when {
-            x > c -> c
-            x < -c -> -c
-            else -> x
+    private fun updateLimiterCoeffs() {
+        lookaheadSamples = (lookaheadMs / 1000f * sampleRate).toInt().coerceAtLeast(1)
+        if (buffer.size != lookaheadSamples) {
+            buffer = FloatArray(lookaheadSamples)
+            index = 0
         }
+        limiterReleaseCoef = exp(-1f / (releaseMs / 1000f * sampleRate))
     }
 
-    fun reset() {}
+    private fun updateCompressorCoeffs() {
+        compThreshold = 10f.pow(compThresholdDbfs / 20f)
+        compAttackCoef = exp(-1f / (compAttackMs / 1000f * sampleRate))
+        compReleaseCoef = exp(-1f / (compReleaseMs / 1000f * sampleRate))
+    }
+
+    fun process(sample: Float): Float {
+        var x = sample * preGain()
+
+        if (compEnabled) {
+            val inp = abs(x)
+            compEnv = if (inp > compEnv) {
+                compAttackCoef * (compEnv - inp) + inp
+            } else {
+                compReleaseCoef * (compEnv - inp) + inp
+            }
+            val desired = if (compEnv <= compThreshold || compThreshold == 0f) {
+                1f
+            } else {
+                (compThreshold + (compEnv - compThreshold) / compRatio) / compEnv
+            }
+            compGain = if (desired < compGain) {
+                desired
+            } else {
+                compGain + (desired - compGain) * (1 - compReleaseCoef)
+            }
+            x *= compGain
+        }
+
+        // Limiter: push sample into buffer and compute max peak
+        buffer[index] = x
+        var max = 0f
+        for (s in buffer) {
+            val a = abs(s)
+            if (a > max) max = a
+        }
+        val c = ceiling()
+        val desiredGain = if (max <= c) 1f else c / max
+        limiterGain = if (desiredGain < limiterGain) {
+            desiredGain
+        } else {
+            limiterGain + (desiredGain - limiterGain) * (1 - limiterReleaseCoef)
+        }
+        val out = buffer[(index + 1) % buffer.size] * limiterGain
+        index = (index + 1) % buffer.size
+        return out
+    }
+
+    fun reset() {
+        buffer.fill(0f)
+        index = 0
+        limiterGain = 1f
+        compEnv = 0f
+        compGain = 1f
+    }
 }
+

--- a/app/src/main/java/com/example/ssplite/audio/FfpAudioProcessor.kt
+++ b/app/src/main/java/com/example/ssplite/audio/FfpAudioProcessor.kt
@@ -38,6 +38,7 @@ class FfpAudioProcessor : BaseAudioProcessor() {
     override fun onConfigure(inputAudioFormat: AudioFormat): AudioFormat {
         sampleRate = inputAudioFormat.sampleRate
         lfo.setSampleRate(sampleRate)
+        dynamics.setSampleRate(sampleRate)
         preset?.let { applyPreset(it) }
         return inputAudioFormat
     }
@@ -54,6 +55,11 @@ class FfpAudioProcessor : BaseAudioProcessor() {
         }
         dynamics.preGainDb = p.dynamics.pregain_db
         dynamics.ceilingDbfs = p.dynamics.limiter.ceiling_dbfs
+        dynamics.setLookaheadMs(p.dynamics.limiter.lookahead_ms)
+        dynamics.setReleaseMs(p.dynamics.limiter.release_ms)
+        p.dynamics.compressor?.let { c ->
+            dynamics.setCompressor(c.enabled, c.ratio, c.threshold_dbfs, c.attack_ms, c.release_ms)
+        } ?: dynamics.setCompressor(false, 1f, 0f, 1f, 1f)
         lfo.enabled = p.modulation.enabled
         lfo.rateHz = p.modulation.rate_hz
         lfo.depthDb = p.modulation.depth_db

--- a/app/src/test/java/com/example/ssplite/audio/DynamicsTest.kt
+++ b/app/src/test/java/com/example/ssplite/audio/DynamicsTest.kt
@@ -1,16 +1,38 @@
 package com.example.ssplite.audio
 
+import kotlin.math.pow
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.math.pow
+import kotlin.test.assertTrue
 
 class DynamicsTest {
+
     @Test
-    fun preGainAndLimiterApplied() {
-        val dyn = Dynamics(preGainDb = 6f, ceilingDbfs = -1f)
+    fun lookAheadLimiterApplied() {
+        val sr = 48_000
+        val dyn = Dynamics(preGainDb = 6f, ceilingDbfs = -1f, lookaheadMs = 5f, releaseMs = 100f)
+        dyn.setSampleRate(sr)
+        val la = (5f / 1000f * sr).toInt().coerceAtLeast(1)
+
+        repeat(la) { dyn.process(0f) } // prime delay line
+        dyn.process(1f) // loud sample enters buffer
+        var out = 0f
+        repeat(la) { out = dyn.process(0f) } // read delayed sample
+
         val ceiling = 10f.pow(-1f / 20f)
-        val input = 1f
-        val out = dyn.process(input)
         assertEquals(ceiling, out, 1e-6f)
     }
+
+    @Test
+    fun compressorReducesGain() {
+        val sr = 48_000
+        val dyn = Dynamics(preGainDb = 0f, ceilingDbfs = 0f)
+        dyn.setSampleRate(sr)
+        dyn.setCompressor(true, 2f, -20f, 5f, 50f)
+        val threshold = 10f.pow(-20f / 20f)
+        val input = threshold * 2f
+        val out = dyn.process(input)
+        assertTrue(out < input)
+    }
 }
+


### PR DESCRIPTION
## Summary
- replace hard limiter with look-ahead design and configurable release time
- allow optional mild compression in dynamics processing
- hook preset dynamics parameters into audio processor

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ab01e51c832cb3bed04de4e6bab0