### PR TITLE
Release ExoPlayer when PlayerScreen is disposed

### DIFF
--- a/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
@@ -109,6 +109,15 @@ fun PlayerScreen(navController: NavController, testPlayer: ExoPlayer? = null) {
             .also { AudioEngine.player = it }
     }
 
+    DisposableEffect(player) {
+        onDispose {
+            player.release()
+            if (AudioEngine.player == player) {
+                AudioEngine.player = null
+            }
+        }
+    }
+
     val openTree = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocumentTree()) { uri ->
         treeUri = uri
         if (uri != null) {


### PR DESCRIPTION
## Summary
- ensure ExoPlayer is wrapped in a `DisposableEffect`
- release the player and clear shared reference when the screen is disposed

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4b2d7a3dc832c8ee5b8e9c66e2d45