### PR TITLE
Fix Media3 audio processor imports and player configuration

### DIFF
--- a/app/src/main/java/com/example/ssplite/audio/FfpAudioProcessor.kt
+++ b/app/src/main/java/com/example/ssplite/audio/FfpAudioProcessor.kt
@@ -1,7 +1,7 @@
 package com.example.ssplite.audio
 
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.exoplayer.audio.AudioProcessor.AudioFormat
+import androidx.media3.common.audio.AudioProcessor.AudioFormat
 import androidx.media3.exoplayer.audio.BaseAudioProcessor
 import com.example.ssplite.model.Preset
 import java.nio.ByteBuffer

--- a/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
+++ b/app/src/main/java/com/example/ssplite/ui/PlayerScreen.kt
@@ -13,7 +13,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.documentfile.provider.DocumentFile
 import androidx.media3.common.MediaItem
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.audio.DefaultAudioSink
 import com.example.ssplite.audio.AudioEngine
 import com.example.ssplite.audio.FfpAudioProcessor
 import kotlinx.coroutines.Job
@@ -102,11 +104,17 @@ fun PlayerScreen(navController: NavController, testPlayer: ExoPlayer? = null) {
         AudioEngine.processor ?: FfpAudioProcessor().also { AudioEngine.processor = it }
     }
 
+    @OptIn(UnstableApi::class)
     val player = testPlayer ?: remember {
-        AudioEngine.player ?: ExoPlayer.Builder(context)
-            .setAudioProcessors(listOf(processor))
-            .build()
-            .also { AudioEngine.player = it }
+        AudioEngine.player ?: run {
+            val audioSink = DefaultAudioSink.Builder()
+                .setAudioProcessors(processor)
+                .build()
+            ExoPlayer.Builder(context)
+                .setAudioSink(audioSink)
+                .build()
+                .also { AudioEngine.player = it }
+        }
     }
 
     DisposableEffect(player) {


### PR DESCRIPTION
## Summary
- align `FfpAudioProcessor` with Media3's updated AudioProcessor package
- configure `ExoPlayer` using `DefaultAudioSink` and opt in to unstable API when injecting custom audio processor

## Testing
- `./gradlew :app:compileDebugKotlin` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68a618bad7d8832c8f4d17eb5c46b2ee