### PR TITLE
Add simple web demo for audio filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Minimalistische Android-App (Kotlin/Compose + ExoPlayer) für SSP-inspirierte Em
 - Jetpack Compose UI, Kotlin.
 - GitHub Actions Workflow (`.github/workflows/android-release.yml`) baut signierte Release-APK.
 
+## Web-Demo
+Eine einfache Web-Version zum Testen steht im Ordner `web/`. Öffne `web/index.html` in einem aktuellen Browser, um Audio abzuspielen und Filtereinstellungen auszuprobieren.
 ## Keystore
 Siehe [KEYS.md](KEYS.md) für Erstellung des Keystores und GitHub-Secrets.
 

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>SSPLite Web</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <h1>SSPLite Web</h1>
+  <input type="file" id="file" accept="audio/*">
+  <button id="play" disabled>Play</button>
+  <button id="pause" disabled>Pause</button>
+
+  <section id="filters">
+    <h2>FFP Filters</h2>
+    <div>
+      <label>Low Shelf Gain: <input type="range" id="lowGain" min="-15" max="15" value="0"></label>
+    </div>
+    <div>
+      <label>Peaking 1 Gain: <input type="range" id="peak1Gain" min="-15" max="15" value="0"></label>
+    </div>
+    <div>
+      <label>Peaking 2 Gain: <input type="range" id="peak2Gain" min="-15" max="15" value="0"></label>
+    </div>
+    <div>
+      <label>High Shelf Gain: <input type="range" id="highGain" min="-15" max="15" value="0"></label>
+    </div>
+  </section>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/web/main.js
+++ b/web/main.js
@@ -1,0 +1,72 @@
+const fileInput = document.getElementById('file');
+const playBtn = document.getElementById('play');
+const pauseBtn = document.getElementById('pause');
+
+let audioContext;
+let source;
+let lowShelf, peak1, peak2, highShelf;
+let audioElement;
+
+fileInput.onchange = async () => {
+  const file = fileInput.files[0];
+  if (!file) return;
+
+  if (!audioContext) {
+    audioContext = new (window.AudioContext || window.webkitAudioContext)();
+  }
+
+  if (audioElement) {
+    audioElement.pause();
+    audioElement.remove();
+  }
+
+  const url = URL.createObjectURL(file);
+  audioElement = new Audio(url);
+  audioElement.crossOrigin = "anonymous";
+
+  source = audioContext.createMediaElementSource(audioElement);
+
+  lowShelf = audioContext.createBiquadFilter();
+  lowShelf.type = 'lowshelf';
+  lowShelf.frequency.value = 200;
+
+  peak1 = audioContext.createBiquadFilter();
+  peak1.type = 'peaking';
+  peak1.frequency.value = 1000;
+  peak1.Q.value = 1;
+
+  peak2 = audioContext.createBiquadFilter();
+  peak2.type = 'peaking';
+  peak2.frequency.value = 4000;
+  peak2.Q.value = 1;
+
+  highShelf = audioContext.createBiquadFilter();
+  highShelf.type = 'highshelf';
+  highShelf.frequency.value = 8000;
+
+  source
+    .connect(lowShelf)
+    .connect(peak1)
+    .connect(peak2)
+    .connect(highShelf)
+    .connect(audioContext.destination);
+
+  document.getElementById('lowGain').oninput = e => {
+    lowShelf.gain.value = e.target.value;
+  };
+  document.getElementById('peak1Gain').oninput = e => {
+    peak1.gain.value = e.target.value;
+  };
+  document.getElementById('peak2Gain').oninput = e => {
+    peak2.gain.value = e.target.value;
+  };
+  document.getElementById('highGain').oninput = e => {
+    highShelf.gain.value = e.target.value;
+  };
+
+  playBtn.disabled = false;
+  pauseBtn.disabled = false;
+
+  playBtn.onclick = () => audioElement.play();
+  pauseBtn.onclick = () => audioElement.pause();
+};

--- a/web/style.css
+++ b/web/style.css
@@ -1,0 +1,8 @@
+body {
+  font-family: sans-serif;
+  margin: 2rem;
+}
+
+#filters div {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
## Summary
- add Web Audio API demo to try out SSP-inspired filters in the browser
- document new web demo entry point in README

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a6293fc288832caae31a940f9dffd8