### PR TITLE
Add Vite-based web app scaffold

### DIFF
--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/web-app/index.html
+++ b/web-app/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Web App</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/web-app/package.json
+++ b/web-app/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "web-app",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "devDependencies": {
+    "vite": "^5.0.0"
+  }
+}

--- a/web-app/src/main.js
+++ b/web-app/src/main.js
@@ -1,0 +1,1 @@
+document.querySelector('#app').textContent = 'Hello, web-app!';

--- a/web-app/vite.config.js
+++ b/web-app/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  root: '.',
+});


### PR DESCRIPTION
## Summary
- scaffold `web-app` folder with Vite config, entry point and dev/build scripts

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `npm run build` *(fails: vite: not found)*
- `npm run dev` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a62e16be2c832c9f54178106790906