### PR TITLE
feat(web): add directory playlist parsing

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,8 +8,10 @@
 <body>
   <h1>SSPLite Web</h1>
   <input type="file" id="file" accept="audio/*">
+  <input type="file" id="dir" webkitdirectory multiple>
   <button id="play" disabled>Play</button>
   <button id="pause" disabled>Pause</button>
+  <ul id="playlist"></ul>
 
   <section id="filters">
     <h2>FFP Filters</h2>


### PR DESCRIPTION
## Summary
- allow selecting folders through `<input webkitdirectory>`
- parse M3U/M3U8 files into playlist entries (File/URL)
- render selectable playlist items for playback

## Testing
- `npm --prefix web-app test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a6b7235b9c832ca318cfbde919e124