### PR TITLE
Load presets from public folder

### DIFF
--- a/web-app/public/presets/01_social_voice.json
+++ b/web-app/public/presets/01_social_voice.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Soziale Stimme",
+  "eq": {
+    "low_shelf": { "fc_hz": 150, "gain_db": -10 },
+    "peaks": [
+      { "fc_hz": 1000, "gain_db": 4, "q": 1.0 },
+      { "fc_hz": 2000, "gain_db": 4, "q": 1.0 }
+    ],
+    "high_shelf": { "fc_hz": 5000, "gain_db": -8 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": false,
+    "rate_hz": 0.05,
+    "depth_db": 0.8,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/web-app/public/presets/02_weiche_prosodie.json
+++ b/web-app/public/presets/02_weiche_prosodie.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Weiche Prosodie",
+  "eq": {
+    "low_shelf": { "fc_hz": 150, "gain_db": -8 },
+    "peaks": [
+      { "fc_hz": 900, "gain_db": 3, "q": 0.8 },
+      { "fc_hz": 1800, "gain_db": 3, "q": 0.8 }
+    ],
+    "high_shelf": { "fc_hz": 6000, "gain_db": -6 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": true,
+    "rate_hz": 0.05,
+    "depth_db": 0.5,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/web-app/public/presets/03_kinderstimme.json
+++ b/web-app/public/presets/03_kinderstimme.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Kinderstimme-Fokus",
+  "eq": {
+    "low_shelf": { "fc_hz": 180, "gain_db": -10 },
+    "peaks": [
+      { "fc_hz": 1500, "gain_db": 3, "q": 1.0 },
+      { "fc_hz": 2800, "gain_db": 5, "q": 0.9 }
+    ],
+    "high_shelf": { "fc_hz": 6000, "gain_db": -6 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": false,
+    "rate_hz": 0.05,
+    "depth_db": 0.8,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/web-app/public/presets/04_maennerstimme.json
+++ b/web-app/public/presets/04_maennerstimme.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Männerstimme-Fokus",
+  "eq": {
+    "low_shelf": { "fc_hz": 140, "gain_db": -8 },
+    "peaks": [
+      { "fc_hz": 800, "gain_db": 4, "q": 1.0 },
+      { "fc_hz": 1600, "gain_db": 3, "q": 1.0 }
+    ],
+    "high_shelf": { "fc_hz": 4500, "gain_db": -6 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": true,
+    "rate_hz": 0.04,
+    "depth_db": 0.0,
+    "mode": "fc",
+    "fc_drift_oct": 0.25,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/web-app/public/presets/05_konservativ.json
+++ b/web-app/public/presets/05_konservativ.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Konservativ",
+  "eq": {
+    "low_shelf": { "fc_hz": 160, "gain_db": -6 },
+    "peaks": [
+      { "fc_hz": 1200, "gain_db": 2, "q": 1.0 },
+      { "fc_hz": 2200, "gain_db": 2, "q": 1.0 }
+    ],
+    "high_shelf": { "fc_hz": 5500, "gain_db": -4 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": false,
+    "rate_hz": 0.05,
+    "depth_db": 0.8,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.1
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}

--- a/web-app/public/presets/06_komfort_plus.json
+++ b/web-app/public/presets/06_komfort_plus.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "name": "Komfort Plus",
+  "eq": {
+    "low_shelf": { "fc_hz": 150, "gain_db": -8 },
+    "peaks": [
+      { "fc_hz": 1000, "gain_db": 3, "q": 1.0 },
+      { "fc_hz": 2200, "gain_db": 3, "q": 1.0 }
+    ],
+    "high_shelf": { "fc_hz": 5500, "gain_db": -6 },
+    "tilt_db": 0
+  },
+  "modulation": {
+    "enabled": true,
+    "rate_hz": 0.06,
+    "depth_db": 0.8,
+    "mode": "gain",
+    "fc_drift_oct": 0.0,
+    "jitter": 0.05
+  },
+  "dynamics": {
+    "pregain_db": -3,
+    "limiter": { "ceiling_dbfs": -1.0, "lookahead_ms": 5, "release_ms": 100 },
+    "compressor": { "enabled": false, "ratio": 1.3, "threshold_dbfs": -24, "attack_ms": 15, "release_ms": 120 }
+  }
+}


### PR DESCRIPTION
## Summary
- copy preset JSON files into `web-app/public/presets`
- load preset files on FilterScreen init and show them in the preset menu

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c0be0258832ca3c7249326d6c510